### PR TITLE
Fix admin user not included in admin group

### DIFF
--- a/user/src/main/openliberty/config/server.xml
+++ b/user/src/main/openliberty/config/server.xml
@@ -24,11 +24,8 @@
         <user name="koos@gmail.com" password="{xor}NDAwLC8oOw==" />   <!-- koospwd -->
         <user name="minki@gmail.com" password="{xor}MjYxNDYvKDs=" />   <!-- minkipwd -->
 
-        <group name="Administrator">
-            <member name="admin" />
-        </group>
-        
         <group name="admin">    
+            <member name="admin" />
             <member name="phillip.kruger@gmail.com" />
         </group>
 


### PR DESCRIPTION
It seems that "Administrator" group is not used anywhere and admin user should be included in admin group - it will be default choice for most users